### PR TITLE
config: use config from env if available

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/viper"
 )
@@ -39,7 +40,12 @@ type Config struct {
 }
 
 func GetConfigure() (*Config, error) {
-	viper.SetConfigName("config")
+	configName := os.Getenv("VS_CONFIG_NAME")
+	if configName == "" {
+		configName = "config"
+	}
+
+	viper.SetConfigName(configName)
 	viper.AddConfigPath(".")
 	viper.AutomaticEnv()
 


### PR DESCRIPTION
This allows us to run multiple instances of vultiserver with varying configurations by using `VS_CONFIG_NAME` to select the appropriate file.

It is an easier option to handling Viper's weirdness around env var handling (may do that at a later stage as the config complexity grows)

Now, you can specify two files, for example:

```
server:
  port: "8080"
  host: "localhost"
  vaults_file_path: "/tmp/vultisigner/server/vaults"
```

```
server:
  port: "8081"
  host: "localhost"
  vaults_file_path: "/tmp/vultisigner/plugin/vaults"
```

and run two instances of vultiserver on difrerent ports

You'd also want to change the redis db number to avoid them clobbering each others queues.