### PR TITLE
Plugin Interface

### DIFF
--- a/cmd/vultisigner/main.go
+++ b/cmd/vultisigner/main.go
@@ -52,7 +52,8 @@ func main() {
 		redisStorage,
 		client,
 		inspector,
-		cfg.Server.VaultsFilePath, sdClient, blockStorage)
+		cfg.Server.VaultsFilePath, sdClient, blockStorage,
+		cfg.Server.Mode, cfg.Plugin.Type)
 	if err := server.StartServer(); err != nil {
 		panic(err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -12,7 +12,13 @@ type Config struct {
 		Port           int64  `mapstructure:"port" json:"port,omitempty"`
 		Host           string `mapstructure:"host" json:"host,omitempty"`
 		VaultsFilePath string `mapstructure:"vaults_file_path" json:"vaults_file_path,omitempty"`
+		Mode           string `mapstructure:"mode" json:"mode,omitempty"`
 	} `mapstructure:"server" json:"server"`
+
+	Plugin struct {
+		Type         string                 `mapstructure:"type" json:"type,omitempty"`
+		PluginConfig map[string]interface{} `mapstructure:"plugin_config" json:"plugin_config,omitempty"`
+	} `mapstructure:"plugin" json:"plugin,omitempty"`
 
 	Redis struct {
 		Host     string `mapstructure:"host" json:"host,omitempty"`
@@ -52,6 +58,7 @@ func GetConfigure() (*Config, error) {
 	viper.SetDefault("Server.Port", 8080)
 	viper.SetDefault("Server.Host", "localhost")
 	viper.SetDefault("Server.VaultsFilePath", "vaults")
+	viper.SetDefault("Server.Mode", "vultiserver")
 	viper.SetDefault("Redis.Host", "localhost")
 	viper.SetDefault("Redis.Port", "6379")
 	viper.SetDefault("Redis.User", "")

--- a/plugin/payroll/frontend/index.html
+++ b/plugin/payroll/frontend/index.html
@@ -1,0 +1,9 @@
+<html>
+  <head>
+    <title>My First Web Page</title>
+  </head>
+  <body>
+    <h1>Welcome to my first web page!</h1>
+    <p>This is a paragraph of text.</p>
+  </body>
+</html>

--- a/plugin/payroll/payroll.go
+++ b/plugin/payroll/payroll.go
@@ -1,9 +1,14 @@
 package payroll
 
 import (
+	"embed"
+
 	"github.com/labstack/echo/v4"
 	"github.com/vultisig/vultisigner/internal/types"
 )
+
+//go:embed frontend
+var frontend embed.FS
 
 type PayrollPlugin struct{}
 
@@ -21,4 +26,8 @@ func (p *PayrollPlugin) ValidatePluginPolicy(policyDoc types.PluginPolicy) error
 
 func (p *PayrollPlugin) ConfigurePlugin(e echo.Context) error {
 	return nil
+}
+
+func (p *PayrollPlugin) Frontend() embed.FS {
+	return frontend
 }

--- a/plugin/payroll/payroll.go
+++ b/plugin/payroll/payroll.go
@@ -1,0 +1,24 @@
+package payroll
+
+import (
+	"github.com/labstack/echo/v4"
+	"github.com/vultisig/vultisigner/internal/types"
+)
+
+type PayrollPlugin struct{}
+
+func NewPayrollPlugin() *PayrollPlugin {
+	return &PayrollPlugin{}
+}
+
+func (p *PayrollPlugin) SignPluginMessages(e echo.Context) error {
+	return nil
+}
+
+func (p *PayrollPlugin) ValidatePluginPolicy(policyDoc types.PluginPolicy) error {
+	return nil
+}
+
+func (p *PayrollPlugin) ConfigurePlugin(e echo.Context) error {
+	return nil
+}

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -1,0 +1,12 @@
+package plugin
+
+import (
+	"github.com/labstack/echo/v4"
+	"github.com/vultisig/vultisigner/internal/types"
+)
+
+type Plugin interface {
+	SignPluginMessages(c echo.Context) error
+	ValidatePluginPolicy(policyDoc types.PluginPolicy) error
+	ConfigurePlugin(c echo.Context) error
+}

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -1,6 +1,8 @@
 package plugin
 
 import (
+	"embed"
+
 	"github.com/labstack/echo/v4"
 	"github.com/vultisig/vultisigner/internal/types"
 )
@@ -9,4 +11,5 @@ type Plugin interface {
 	SignPluginMessages(c echo.Context) error
 	ValidatePluginPolicy(policyDoc types.PluginPolicy) error
 	ConfigurePlugin(c echo.Context) error
+	Frontend() embed.FS
 }


### PR DESCRIPTION
This PR makes the structure changes necessary to enforce a plugin interface. Notably, it adds support for:

1. Explicitly running vultiserver in either `vultiserver` or `pluginserver` mode.
2. Serving of an embedded frontend application from within the plugin definition
3. Laying the base structure to move policy and tx handling into plugin implementation from server