### PR TITLE
storage,types: refactor time trigger to use interface

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -43,7 +43,7 @@ type Server struct {
 	blockStorage  *storage.BlockStorage
 	mode          string
 	plugin        plugin.Plugin
-	db            *postgres.PostgresBackend
+	db            storage.DatabaseStorage
 	scheduler     *scheduler.SchedulerService
 }
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -14,18 +14,18 @@ import (
 	"github.com/vultisig/vultisigner/internal/request"
 	"github.com/vultisig/vultisigner/internal/tasks"
 	"github.com/vultisig/vultisigner/internal/types"
-	"github.com/vultisig/vultisigner/storage/postgres"
+	"github.com/vultisig/vultisigner/storage"
 )
 
 type SchedulerService struct {
-	db        *postgres.PostgresBackend
+	db        storage.DatabaseStorage
 	logger    *logrus.Logger
 	client    *asynq.Client
 	inspector *asynq.Inspector
 	done      chan struct{}
 }
 
-func NewSchedulerService(db *postgres.PostgresBackend, logger *logrus.Logger, client *asynq.Client) *SchedulerService {
+func NewSchedulerService(db storage.DatabaseStorage, logger *logrus.Logger, client *asynq.Client) *SchedulerService {
 	if db == nil {
 		logger.Fatal("database connection is nil")
 	}
@@ -225,7 +225,7 @@ func (s *SchedulerService) CreateTimeTrigger(policy types.PluginPolicy) error {
 
 	cronExpr := frequencyToCron(policySchedule.Schedule.Frequency, policySchedule.Schedule.StartTime)
 
-	trigger := postgres.TimeTrigger{
+	trigger := types.TimeTrigger{
 		PolicyID:       policy.ID,
 		CronExpression: cronExpr,
 		StartTime:      policySchedule.Schedule.StartTime,

--- a/internal/types/time_trigger.go
+++ b/internal/types/time_trigger.go
@@ -1,0 +1,12 @@
+package types
+
+import "time"
+
+type TimeTrigger struct {
+	PolicyID       string
+	CronExpression string
+	StartTime      time.Time
+	EndTime        *time.Time
+	Frequency      string
+	LastExecution  *time.Time
+}

--- a/storage/db.go
+++ b/storage/db.go
@@ -6,4 +6,5 @@ type DatabaseStorage interface {
 	Close() error
 
 	InsertPluginPolicy(policyDoc types.PluginPolicy) error
+	CreateTimeTrigger(trigger types.TimeTrigger) error
 }

--- a/storage/db.go
+++ b/storage/db.go
@@ -6,5 +6,9 @@ type DatabaseStorage interface {
 	Close() error
 
 	InsertPluginPolicy(policyDoc types.PluginPolicy) error
+	GetPluginPolicy(id string) (types.PluginPolicy, error)
+
 	CreateTimeTrigger(trigger types.TimeTrigger) error
+	GetPendingTriggers() ([]types.TimeTrigger, error)
+	UpdateTriggerExecution(policyID string) error
 }

--- a/storage/postgres/db.go
+++ b/storage/postgres/db.go
@@ -5,7 +5,6 @@ import (
 	"embed"
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jackc/pgx/v5/stdlib"
@@ -60,7 +59,7 @@ func (d *PostgresBackend) Migrate() error {
 	return nil
 }
 
-func (p *PostgresBackend) CreateTimeTrigger(trigger TimeTrigger) error {
+func (p *PostgresBackend) CreateTimeTrigger(trigger types.TimeTrigger) error {
 	logrus.Info("Creating time trigger in database")
 	if p.pool == nil {
 		return fmt.Errorf("database pool is nil")
@@ -81,7 +80,7 @@ func (p *PostgresBackend) CreateTimeTrigger(trigger TimeTrigger) error {
 	return err
 }
 
-func (p *PostgresBackend) GetPendingTriggers() ([]TimeTrigger, error) {
+func (p *PostgresBackend) GetPendingTriggers() ([]types.TimeTrigger, error) {
 	if p.pool == nil {
 		return nil, fmt.Errorf("database pool is nil")
 	}
@@ -98,9 +97,9 @@ func (p *PostgresBackend) GetPendingTriggers() ([]TimeTrigger, error) {
 	}
 	defer rows.Close()
 
-	var triggers []TimeTrigger
+	var triggers []types.TimeTrigger
 	for rows.Next() {
-		var t TimeTrigger
+		var t types.TimeTrigger
 		err := rows.Scan(
 			&t.PolicyID,
 			&t.CronExpression,
@@ -129,15 +128,6 @@ func (p *PostgresBackend) UpdateTriggerExecution(policyID string) error {
 
 	_, err := p.pool.Exec(context.Background(), query, policyID)
 	return err
-}
-
-type TimeTrigger struct {
-	PolicyID       string
-	CronExpression string
-	StartTime      time.Time
-	EndTime        *time.Time
-	Frequency      string
-	LastExecution  *time.Time
 }
 
 func (p *PostgresBackend) GetPluginPolicy(id string) (types.PluginPolicy, error) {

--- a/storage/postgres/db.go
+++ b/storage/postgres/db.go
@@ -3,14 +3,12 @@ package postgres
 import (
 	"context"
 	"embed"
-	"encoding/json"
 	"fmt"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/pressly/goose/v3"
 	"github.com/sirupsen/logrus"
-	"github.com/vultisig/vultisigner/internal/types"
 )
 
 //go:embed migrations/*
@@ -57,107 +55,4 @@ func (d *PostgresBackend) Migrate() error {
 	}
 	logrus.Info("Database migration completed successfully")
 	return nil
-}
-
-func (p *PostgresBackend) CreateTimeTrigger(trigger types.TimeTrigger) error {
-	logrus.Info("Creating time trigger in database")
-	if p.pool == nil {
-		return fmt.Errorf("database pool is nil")
-	}
-
-	query := `
-        INSERT INTO time_triggers 
-        (policy_id, cron_expression, start_time, end_time, frequency) 
-        VALUES ($1, $2, $3, $4, $5)`
-
-	_, err := p.pool.Exec(context.Background(), query,
-		trigger.PolicyID,
-		trigger.CronExpression,
-		trigger.StartTime,
-		trigger.EndTime,
-		trigger.Frequency)
-
-	return err
-}
-
-func (p *PostgresBackend) GetPendingTriggers() ([]types.TimeTrigger, error) {
-	if p.pool == nil {
-		return nil, fmt.Errorf("database pool is nil")
-	}
-
-	query := `
-        SELECT policy_id, cron_expression, start_time, end_time, frequency, last_execution 
-        FROM time_triggers 
-        WHERE start_time <= NOW() 
-        AND (end_time IS NULL OR end_time > NOW())` //should we get them 1 min before? so that the tx is settled at the exact time
-
-	rows, err := p.pool.Query(context.Background(), query)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	var triggers []types.TimeTrigger
-	for rows.Next() {
-		var t types.TimeTrigger
-		err := rows.Scan(
-			&t.PolicyID,
-			&t.CronExpression,
-			&t.StartTime,
-			&t.EndTime,
-			&t.Frequency,
-			&t.LastExecution)
-		if err != nil {
-			return nil, err
-		}
-		triggers = append(triggers, t)
-	}
-
-	return triggers, nil
-}
-
-func (p *PostgresBackend) UpdateTriggerExecution(policyID string) error {
-	if p.pool == nil {
-		return fmt.Errorf("database pool is nil")
-	}
-
-	query := `
-        UPDATE time_triggers 
-        SET last_execution = NOW() 
-        WHERE policy_id = $1`
-
-	_, err := p.pool.Exec(context.Background(), query, policyID)
-	return err
-}
-
-func (p *PostgresBackend) GetPluginPolicy(id string) (types.PluginPolicy, error) {
-	if p.pool == nil {
-		return types.PluginPolicy{}, fmt.Errorf("database pool is nil")
-	}
-
-	var policy types.PluginPolicy
-	var policyJSON []byte
-
-	query := `
-        SELECT id, public_key, plugin_id, plugin_version, policy_version, plugin_type, signature, policy 
-        FROM plugin_policies 
-        WHERE id = $1`
-
-	err := p.pool.QueryRow(context.Background(), query, id).Scan(
-		&policy.ID,
-		&policy.PublicKey,
-		&policy.PluginID,
-		&policy.PluginVersion,
-		&policy.PolicyVersion,
-		&policy.PluginType,
-		&policy.Signature,
-		&policyJSON,
-	)
-
-	if err != nil {
-		return types.PluginPolicy{}, fmt.Errorf("failed to get policy: %w", err)
-	}
-
-	policy.Policy = json.RawMessage(policyJSON)
-	return policy, nil
 }

--- a/storage/postgres/policy.go
+++ b/storage/postgres/policy.go
@@ -18,3 +18,35 @@ func (d *PostgresBackend) InsertPluginPolicy(policyDoc types.PluginPolicy) error
 
 	return err
 }
+
+func (p *PostgresBackend) GetPluginPolicy(id string) (types.PluginPolicy, error) {
+	if p.pool == nil {
+		return types.PluginPolicy{}, fmt.Errorf("database pool is nil")
+	}
+
+	var policy types.PluginPolicy
+	var policyJSON []byte
+
+	query := `
+        SELECT id, public_key, plugin_id, plugin_version, policy_version, plugin_type, signature, policy 
+        FROM plugin_policies 
+        WHERE id = $1`
+
+	err := p.pool.QueryRow(context.Background(), query, id).Scan(
+		&policy.ID,
+		&policy.PublicKey,
+		&policy.PluginID,
+		&policy.PluginVersion,
+		&policy.PolicyVersion,
+		&policy.PluginType,
+		&policy.Signature,
+		&policyJSON,
+	)
+
+	if err != nil {
+		return types.PluginPolicy{}, fmt.Errorf("failed to get policy: %w", err)
+	}
+
+	policy.Policy = json.RawMessage(policyJSON)
+	return policy, nil
+}

--- a/storage/postgres/time_trigger.go
+++ b/storage/postgres/time_trigger.go
@@ -1,0 +1,80 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"github.com/vultisig/vultisigner/internal/types"
+)
+
+func (p *PostgresBackend) CreateTimeTrigger(trigger types.TimeTrigger) error {
+	logrus.Info("Creating time trigger in database")
+	if p.pool == nil {
+		return fmt.Errorf("database pool is nil")
+	}
+
+	query := `
+        INSERT INTO time_triggers 
+        (policy_id, cron_expression, start_time, end_time, frequency) 
+        VALUES ($1, $2, $3, $4, $5)`
+
+	_, err := p.pool.Exec(context.Background(), query,
+		trigger.PolicyID,
+		trigger.CronExpression,
+		trigger.StartTime,
+		trigger.EndTime,
+		trigger.Frequency)
+
+	return err
+}
+
+func (p *PostgresBackend) GetPendingTriggers() ([]types.TimeTrigger, error) {
+	if p.pool == nil {
+		return nil, fmt.Errorf("database pool is nil")
+	}
+
+	query := `
+        SELECT policy_id, cron_expression, start_time, end_time, frequency, last_execution 
+        FROM time_triggers 
+        WHERE start_time <= NOW() 
+        AND (end_time IS NULL OR end_time > NOW())` //should we get them 1 min before? so that the tx is settled at the exact time
+
+	rows, err := p.pool.Query(context.Background(), query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var triggers []types.TimeTrigger
+	for rows.Next() {
+		var t types.TimeTrigger
+		err := rows.Scan(
+			&t.PolicyID,
+			&t.CronExpression,
+			&t.StartTime,
+			&t.EndTime,
+			&t.Frequency,
+			&t.LastExecution)
+		if err != nil {
+			return nil, err
+		}
+		triggers = append(triggers, t)
+	}
+
+	return triggers, nil
+}
+
+func (p *PostgresBackend) UpdateTriggerExecution(policyID string) error {
+	if p.pool == nil {
+		return fmt.Errorf("database pool is nil")
+	}
+
+	query := `
+        UPDATE time_triggers 
+        SET last_execution = NOW() 
+        WHERE policy_id = $1`
+
+	_, err := p.pool.Exec(context.Background(), query, policyID)
+	return err
+}


### PR DESCRIPTION
Normalized all SQL db access to go through the interface

This is important since we need to be able to mock it out/switch to other DBs easily - will make writing tests later much easier as well.