### PR TITLE
api: properly handle policy workflow on API, create test scripts

### DIFF
--- a/api/plugin.go
+++ b/api/plugin.go
@@ -141,18 +141,6 @@ func (s *Server) CreatePluginPolicy(c echo.Context) error {
 		return fmt.Errorf("fail to parse request, err: %w", err)
 	}
 
-	// Original policy storage logic (to be deleted when the new on works)
-	/*policyPath := fmt.Sprintf("policies/%s.json", policy.ID)
-	content, err := json.Marshal(policy)
-	if err != nil {
-		return fmt.Errorf("fail to marshal policy, err: %w", err)
-	}
-
-	if err := s.blockStorage.UploadFile(content, policyPath); err != nil {
-		return fmt.Errorf("fail to upload file, err: %w", err)
-	}*/
-
-	//new policy+trigger storage logic
 	if err := s.db.InsertPluginPolicy(policy); err != nil {
 		return fmt.Errorf("failed to insert policy: %w", err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -55,6 +55,10 @@ func GetConfigure() (*Config, error) {
 		configName = "config"
 	}
 
+	return ReadConfig(configName)
+}
+
+func ReadConfig(configName string) (*Config, error) {
 	viper.SetConfigName(configName)
 	viper.AddConfigPath(".")
 	viper.AutomaticEnv()

--- a/internal/types/policy.go
+++ b/internal/types/policy.go
@@ -32,5 +32,5 @@ type PayrollRecipient struct {
 type Schedule struct {
 	Frequency string `json:"frequency"`
 	StartTime string `json:"start_time"`
-	EndTime   string `json:"end_time"`
+	EndTime   string `json:"end_time,omitempty"`
 }

--- a/scripts/dev/create_payroll_policy.go
+++ b/scripts/dev/create_payroll_policy.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/vultisig/vultisigner/config"
+	"github.com/vultisig/vultisigner/internal/types"
+)
+
+var vaultName string
+var stateDir string
+
+func main() {
+	flag.StringVar(&vaultName, "vault", "", "vault name")
+	flag.StringVar(&stateDir, "state-dir", "", "state directory")
+	flag.Parse()
+
+	if vaultName == "" {
+		panic("vault name is required")
+	}
+
+	if stateDir == "" {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			panic(err)
+		}
+
+		stateDir = filepath.Join(homeDir, ".vultiserver", "vaults")
+	}
+
+	keyPath := filepath.Join(stateDir, vaultName, "public_key")
+	rawKey, err := os.ReadFile(keyPath)
+	if err != nil {
+		panic(err)
+	}
+
+	key := string(rawKey)
+
+	fmt.Printf("Public key for vault %s:\n%s\n", vaultName, key)
+
+	serverConfig, err := config.ReadConfig("config-server")
+	if err != nil {
+		panic(err)
+	}
+
+	pluginConfig, err := config.ReadConfig("config-plugin")
+	if err != nil {
+		panic(err)
+	}
+
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Print("Enter token contract: ")
+	tokenContract, _ := reader.ReadString('\n')
+	tokenContract = tokenContract[:len(tokenContract)-1]
+
+	fmt.Println("Enter recipients and amounts one by one - enter 'done' when finished")
+	var done bool
+	var recipientAddresses []string
+	var recipientAmounts []string
+	for !done {
+		fmt.Print("Enter a recipient address: ")
+		recipientAddress, _ := reader.ReadString('\n')
+		recipientAddress = recipientAddress[:len(recipientAddress)-1]
+
+		if recipientAddress == "done" {
+			done = true
+			break
+		}
+
+		fmt.Print("Enter the amount for this recipient: ")
+		recipientAmount, _ := reader.ReadString('\n')
+		recipientAmount = recipientAmount[:len(recipientAmount)-1]
+
+		recipientAddresses = append(recipientAddresses, recipientAddress)
+		recipientAmounts = append(recipientAmounts, recipientAmount)
+	}
+
+	fmt.Printf("Token contract: %s\n", tokenContract)
+	fmt.Printf("Recipients: %d\n", len(recipientAddresses))
+	for i, recipient := range recipientAddresses {
+		fmt.Printf("Recipient %d: %s, Amount: %s\n", i+1, recipient, recipientAmounts[i])
+	}
+
+	fmt.Print("Enter schedule frequency: ")
+	frequency, _ := reader.ReadString('\n')
+	frequency = frequency[:len(frequency)-1]
+
+	policyId := uuid.New().String()
+	policy := types.PluginPolicy{
+		ID:            policyId,
+		PublicKey:     key,
+		PluginID:      "payroll",
+		PluginVersion: "1.0.0",
+		PolicyVersion: "1.0.0",
+		PluginType:    "payroll",
+		Signature:     "0x0000000000000000000000000000000000000000000000000000000000000000",
+	}
+
+	payrollPolicy := types.PayrollPolicy{
+		ChainID:    "1",
+		TokenID:    tokenContract,
+		Recipients: []types.PayrollRecipient{},
+		Schedule: types.Schedule{
+			Frequency: frequency,
+			StartTime: time.Now().UTC().Add(20 * time.Second).Format(time.RFC3339),
+		},
+	}
+
+	for i, recipient := range recipientAddresses {
+		payrollPolicy.Recipients = append(payrollPolicy.Recipients, types.PayrollRecipient{
+			Address: recipient,
+			Amount:  recipientAmounts[i],
+		})
+	}
+
+	policyBytes, err := json.Marshal(payrollPolicy)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Payroll policy", string(policyBytes))
+	policy.Policy = policyBytes
+
+	serverHost := fmt.Sprintf("http://%s:%d", serverConfig.Server.Host, serverConfig.Server.Port)
+	pluginHost := fmt.Sprintf("http://%s:%d", pluginConfig.Server.Host, pluginConfig.Server.Port)
+
+	fmt.Printf("Creating policy on verifier server: %s\n", serverHost)
+	reqBytes, err := json.Marshal(policy)
+	if err != nil {
+		panic(err)
+	}
+
+	resp, err := http.Post(fmt.Sprintf("%s/plugin/policy", serverHost), "application/json", bytes.NewBuffer(reqBytes))
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Request sent: %d\n", resp.StatusCode)
+
+	fmt.Printf("Creating policy on plugin server: %s\n", pluginHost)
+
+	resp, err = http.Post(fmt.Sprintf("%s/plugin/policy", pluginHost), "application/json", bytes.NewBuffer(reqBytes))
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Request sent: %d\n", resp.StatusCode)
+}

--- a/scripts/dev/create_vault.go
+++ b/scripts/dev/create_vault.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/google/uuid"
+	"github.com/vultisig/vultisigner/config"
+	"github.com/vultisig/vultisigner/internal/types"
+)
+
+var vaultName string
+var stateDir string
+
+func main() {
+	flag.StringVar(&vaultName, "vault", "", "vault name")
+	flag.StringVar(&stateDir, "state-dir", "", "state directory")
+	flag.Parse()
+
+	if vaultName == "" {
+		panic("vault name is required")
+	}
+
+	if stateDir == "" {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			panic(err)
+		}
+
+		stateDir = filepath.Join(homeDir, ".vultiserver", "vaults")
+	}
+
+	keyPath := filepath.Join(stateDir, vaultName, "public_key")
+	if _, err := os.Stat(keyPath); err == nil {
+		panic("vault already exists")
+	}
+
+	serverConfig, err := config.ReadConfig("config-server")
+	if err != nil {
+		panic(err)
+	}
+
+	pluginConfig, err := config.ReadConfig("config-plugin")
+	if err != nil {
+		panic(err)
+	}
+
+	createVaultRequest := &types.VaultCreateRequest{
+		Name:               vaultName,
+		SessionID:          uuid.New().String(),
+		HexEncryptionKey:   "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+		HexChainCode:       "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+		LocalPartyId:       "1",
+		EncryptionPassword: "your-secure-password",
+		Email:              "example@example.com",
+		StartSession:       false,
+	}
+
+	serverHost := fmt.Sprintf("http://%s:%d", serverConfig.Server.Host, serverConfig.Server.Port)
+	pluginHost := fmt.Sprintf("http://%s:%d", pluginConfig.Server.Host, pluginConfig.Server.Port)
+
+	fmt.Printf("Creating vault on verifier server: %s\n", serverHost)
+	reqBytes, err := json.Marshal(createVaultRequest)
+	if err != nil {
+		panic(err)
+	}
+
+	resp, err := http.Post(fmt.Sprintf("%s/vault/create", serverHost), "application/json", bytes.NewBuffer(reqBytes))
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Request sent: %d\n", resp.StatusCode)
+
+	fmt.Printf("Creating vault on plugin server: %s\n", pluginHost)
+	createVaultRequest.LocalPartyId = "2"
+	createVaultRequest.StartSession = true
+	createVaultRequest.Parties = []string{"1", "2"}
+
+	reqBytes, err = json.Marshal(createVaultRequest)
+	if err != nil {
+		panic(err)
+	}
+
+	resp, err = http.Post(fmt.Sprintf("%s/vault/create", pluginHost), "application/json", bytes.NewBuffer(reqBytes))
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Request sent: %d\n", resp.StatusCode)
+
+	fmt.Println("Please watch the logs on the worker nodes and retrieve the ECDSA public key")
+
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Print("Enter the ECDSA public key: ")
+	publicKey, _ := reader.ReadString('\n')
+	publicKey = publicKey[:len(publicKey)-1]
+
+	fmt.Printf("Saving vault %s with key %s\n", vaultName, publicKey)
+	vaultPath := filepath.Join(stateDir, vaultName)
+	if err := os.MkdirAll(vaultPath, 0755); err != nil {
+		panic(err)
+	}
+
+	vaultFile, err := os.Create(filepath.Join(vaultPath, "public_key"))
+	if err != nil {
+		panic(err)
+	}
+
+	if _, err := vaultFile.WriteString(publicKey); err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Vault created successfully")
+}


### PR DESCRIPTION
This PR moves away from the hardcoded plugin test flow to a more reusable one. Now we can:

Run `go run scripts/dev/create_vault.go --vault test_1` to create a vault called `test_1` and store its ecdsa public key. This will call both the verification server and the plugin server to create a new 2of2 vault for testing.

Run `go run scripts/dev/create_payroll_policy.go --vault test_1` to use the public key from `test_1` to interactively populate a payroll plugin policy and send it to both servers.

This enables us to have a nice, fast-feedback testing flow where we can create multiple vaults and multiple payroll policies with different configurations trivially.
