### PR TITLE
disallow editing policy properties 2

### DIFF
--- a/plugin/dca/dcaPluginUiSchema.json
+++ b/plugin/dca/dcaPluginUiSchema.json
@@ -40,8 +40,7 @@
                     "properties": {
                         "interval": {
                             "title": "Every",
-                            "type": "string",
-                            "pattern": "^(?!0$)(?!0+\\.0*$)[0-9]+(\\.[0-9]+)?$"
+                            "type": "string"
                         },
                         "frequency": {
                             "type": "string",
@@ -54,6 +53,41 @@
                                 "monthly"
                             ],
                             "default": "minutely"
+                        }
+                    },
+                    "dependencies": {
+                        "frequency": {
+                            "oneOf": [
+                                {
+                                    "properties": {
+                                        "frequency": {
+                                            "enum": [
+                                                "minutely"
+                                            ]
+                                        },
+                                        "interval": {
+                                            "type": "string",
+                                            "pattern": "^(1[5-9]|[2-9][0-9]+)(\\.[0-9]+)?$"
+                                        }
+                                    }
+                                },
+                                {
+                                    "properties": {
+                                        "frequency": {
+                                            "enum": [
+                                                "hourly",
+                                                "daily",
+                                                "weekly",
+                                                "monthly"
+                                            ]
+                                        },
+                                        "interval": {
+                                            "type": "string",
+                                            "pattern": "^(?!0$)(?!0+\\.0*$)[0-9]+(\\.[0-9]+)?$"
+                                        }
+                                    }
+                                }
+                            ]
                         }
                     }
                 },
@@ -132,6 +166,7 @@
                 }
             },
             "schedule": {
+                "ui:hideError": true,
                 "ui:order": [
                     "interval",
                     "frequency"
@@ -141,6 +176,8 @@
                 },
                 "ui:classNames": "form-row",
                 "frequency": {
+                    "ui:readonly": false,
+                    "ui:hideError": true,
                     "ui:classNames": "input-background stacked-input",
                     "ui:style": {
                         "display": "flex",
@@ -148,6 +185,8 @@
                     }
                 },
                 "interval": {
+                    "ui:readonly": false,
+                    "ui:hideError": false,
                     "ui:classNames": "input-background stacked-input",
                     "ui:style": {
                         "display": "flex",
@@ -168,6 +207,7 @@
                     "classNames": "form-row"
                 },
                 "min": {
+                    "ui:readonly": false,
                     "ui:options": {
                         "classNames": "input-background stacked-input",
                         "placeholder": "Min Price"
@@ -179,6 +219,7 @@
                     }
                 },
                 "max": {
+                    "ui:readonly": false,
                     "ui:options": {
                         "classNames": "input-background stacked-input",
                         "label": false,

--- a/plugins-ui/src/__ tests __/policy/PolicyProvider.test.tsx
+++ b/plugins-ui/src/__ tests __/policy/PolicyProvider.test.tsx
@@ -70,7 +70,6 @@ vi.mock("@/modules/policy/services/policyService", () => ({
 
 const TestComponent = () => {
   const { policyMap, addPolicy, updatePolicy, removePolicy } = usePolicies();
-  console.log("policyMap", policyMap);
 
   return (
     <div>
@@ -175,7 +174,7 @@ describe("PolicyProvider", () => {
 
       const consoleErrorSpy = vi
         .spyOn(console, "error")
-        .mockImplementation(() => { });
+        .mockImplementation(() => {});
 
       renderWithProvider();
 

--- a/plugins-ui/src/__ tests __/policy/PolicyTitle.test.tsx
+++ b/plugins-ui/src/__ tests __/policy/PolicyTitle.test.tsx
@@ -2,16 +2,10 @@ import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { RJSFSchema, TitleFieldProps } from "@rjsf/utils";
 import { TitleFieldTemplate } from "@/modules/policy/components/policy-title/PolicyTitle";
+import { USDC_TOKEN, WETH_TOKEN } from "@/modules/shared/data/tokens";
 
 const schema: RJSFSchema = {
   title: "DCA Plugin Policy",
-};
-
-const uiSchema = {
-  "ui:options": {
-    source_token_id: "source_token_id",
-    destination_token_id: "destination_token_id",
-  },
 };
 
 const mockRegistry: TitleFieldProps["registry"] = {
@@ -66,13 +60,22 @@ describe("TitleFieldTemplate", () => {
   });
 
   it("should render custom title template if tokens are provided in ui:options", () => {
+    const registry = {
+      ...mockRegistry,
+      ...{
+        formContext: {
+          sourceTokenId: WETH_TOKEN,
+          destinationTokenId: USDC_TOKEN,
+          editing: true,
+        },
+      },
+    };
     render(
       <TitleFieldTemplate
         id="title"
         title="Title"
         schema={schema}
-        uiSchema={uiSchema}
-        registry={mockRegistry}
+        registry={registry}
       />
     );
 

--- a/plugins-ui/src/modules/policy/components/policy-form/PolicyForm.css
+++ b/plugins-ui/src/modules/policy/components/policy-form/PolicyForm.css
@@ -66,6 +66,11 @@ fieldset {
     }
 }
 
+input:read-only {
+    cursor: not-allowed;
+    color: var(--text-disabled-color); 
+}
+
 .text-danger {
     color: var(--alert-error-color);
     list-style-type: none;

--- a/plugins-ui/src/modules/policy/components/policy-form/PolicyForm.tsx
+++ b/plugins-ui/src/modules/policy/components/policy-form/PolicyForm.tsx
@@ -81,7 +81,12 @@ const PolicyForm = ({ data, onSubmitCallback }: PolicyFormProps) => {
   const transformErrors = (errors: RJSFValidationError[]) => {
     return errors.map((error) => {
       if (error.name === "pattern") {
-        error.message = "should be a positive number";
+        if (error.params.pattern === "^(1[5-9]|[2-9][0-9]+)(\\.[0-9]+)?$") {
+          error.message = "should be a positive number above 15";
+        }
+        if (error.params.pattern === "^(?!0$)(?!0+\\.0*$)[0-9]+(\\.[0-9]+)?$") {
+          error.message = "should be a positive number";
+        }
       }
       if (error.name === "required") {
         error.message = "required";
@@ -107,7 +112,12 @@ const PolicyForm = ({ data, onSubmitCallback }: PolicyFormProps) => {
           widgets={{ TokenSelector, WeiConverter }}
           transformErrors={transformErrors}
           liveValidate={!!policyId}
-          formContext={{ sourceTokenId: formData.source_token_id as string }} // sourceTokenId is needed in WeiConverter to get the rigth decimal places based on token address
+          readonly={!!policyId}
+          formContext={{
+            editing: !!policyId,
+            sourceTokenId: formData.source_token_id as string, // sourceTokenId is needed in WeiConverter/TitleFieldTemplate and probably on most of the existing plugins to get the rigth decimal places based on token address
+            destinationTokenId: formData.destination_token_id as string, // destinationTokenId is needed in TitleFieldTemplate
+          }}
         />
       )}
     </div>

--- a/plugins-ui/src/modules/policy/components/policy-title/PolicyTitle.tsx
+++ b/plugins-ui/src/modules/policy/components/policy-title/PolicyTitle.tsx
@@ -2,27 +2,20 @@ import TokenPair from "@/modules/shared/token-pair/TokenPair";
 import { TitleFieldProps } from "@rjsf/utils";
 
 export function TitleFieldTemplate(props: TitleFieldProps) {
-  const { id, title, uiSchema } = props;
+  const { id, title, registry } = props;
 
-  let source_token_id, destination_token_id;
-  if (
-    uiSchema?.["ui:options"] &&
-    uiSchema["ui:options"]?.["source_token_id"] &&
-    uiSchema["ui:options"]?.["destination_token_id"]
-  ) {
-    source_token_id = uiSchema["ui:options"]["source_token_id"] as string;
-    destination_token_id = uiSchema["ui:options"][
-      "destination_token_id"
-    ] as string;
-  }
+  let source_token_id = registry.formContext?.sourceTokenId;
+  let destination_token_id = registry.formContext?.destinationTokenId;
+
+  const editingForm = registry.formContext?.editing;
 
   return (
     <header style={{ fontSize: "2.125rem" }} id={id} data-testid={id}>
-      {source_token_id && destination_token_id && (
+      {editingForm && source_token_id && destination_token_id && (
         <TokenPair data={[source_token_id, destination_token_id]} />
       )}
 
-      {(!source_token_id || !destination_token_id) && title}
+      {(!editingForm || !source_token_id || !destination_token_id) && title}
     </header>
   );
 }

--- a/plugins-ui/src/modules/shared/token-selector/TokenSelector.tsx
+++ b/plugins-ui/src/modules/shared/token-selector/TokenSelector.tsx
@@ -4,13 +4,13 @@ import Search from "@/assets/Search.svg?react";
 import { cloneElement, useState } from "react";
 import { supportedTokens } from "@/modules/shared/data/tokens";
 import Modal from "@/modules/core/components/ui/modal/Modal";
+import { WidgetProps } from "@rjsf/utils";
 
-type TokenSelectorProps = {
-  value: string;
-  onChange: (tokenId: string) => void;
-};
-
-const TokenSelector = ({ value, onChange }: TokenSelectorProps) => {
+const TokenSelector: React.FC<WidgetProps> = ({
+  value,
+  readonly,
+  onChange,
+}) => {
   const [isModalOpen, setModalOpen] = useState(false);
   const [search, setSearch] = useState("");
   const [token, setToken] = useState(supportedTokens[value]);
@@ -35,11 +35,13 @@ const TokenSelector = ({ value, onChange }: TokenSelectorProps) => {
         style={{
           justifyContent: "space-between",
           backgroundColor: "#061B3A",
+          color: readonly ? "#718096" : "auto",
           border: "1px solid #11284A",
           borderRadius: "12px",
           width: "100%",
+          cursor: readonly ? "not-allowed" : "pointer",
         }}
-        onClick={() => setModalOpen(true)}
+        onClick={() => !readonly && setModalOpen(true)}
       >
         {token && cloneElement(token.image, { width: 24, height: 24 })}&nbsp;
         {token?.name || "Unknown token"}

--- a/plugins-ui/src/modules/shared/wei-converter/WeiConverter.css
+++ b/plugins-ui/src/modules/shared/wei-converter/WeiConverter.css
@@ -5,4 +5,9 @@
 
     border-radius: 12px;
     padding: 16px;
+
+    &:read-only {
+        color: var(--text-disabled-color); 
+        cursor: not-allowed;
+    }
 }

--- a/plugins-ui/src/modules/shared/wei-converter/WeiConverter.tsx
+++ b/plugins-ui/src/modules/shared/wei-converter/WeiConverter.tsx
@@ -8,6 +8,7 @@ const DEBOUNCE_DELAY = 500;
 
 const WeiConverter: React.FC<WidgetProps> = ({
   value,
+  readonly,
   onChange,
   formContext,
   schema,
@@ -61,6 +62,7 @@ const WeiConverter: React.FC<WidgetProps> = ({
         id="wei"
         type="number"
         value={inputValue}
+        readOnly={readonly}
         onChange={handleChange}
         data-testid="wei-converter"
       />

--- a/plugins-ui/variables.css
+++ b/plugins-ui/variables.css
@@ -22,6 +22,7 @@
 
     /* text colors */
     --text-primary-color: #F0F4FC;
+    --text-disabled-color: #718096;
     --text-light-color: #C9D6E8;
     --text-extra-light-color: #8295AE;
     --text-dark-color: #02122B;


### PR DESCRIPTION
For certain policy properties, rather than editing them, it is better to delete and create a new policy.
In cases of bugs, debugging may be challenging (we do not support change logs or anything like that) and it could potentially mess up the execution of the policy.
* [x] source token, destination token, total amount

For certain properties, it probably makes sense to allow for changes (frequency, price range)