### PR TITLE
scripts/create_vault: explicitly handle StartSession

### DIFF
--- a/api/plugin.go
+++ b/api/plugin.go
@@ -96,7 +96,6 @@ func (s *Server) SignPluginMessages(c echo.Context) error {
 		return fmt.Errorf("fail to decrypt vault from the backup, err: %w", err)
 	}
 
-	req.StartSession = false
 	req.Parties = []string{common.PluginPartyID, common.VerifierPartyID}
 
 	buf, err := json.Marshal(req)

--- a/internal/types/keysign.go
+++ b/internal/types/keysign.go
@@ -12,7 +12,6 @@ type KeysignRequest struct {
 	DerivePath       string   `json:"derive_path"`        // Derive Path
 	IsECDSA          bool     `json:"is_ecdsa"`           // indicate use ECDSA or EDDSA key to sign the messages
 	VaultPassword    string   `json:"vault_password"`     // password used to decrypt the vault file
-	StartSession     bool     `json:"start_session"`      // indicate start a new session or not
 	Parties          []string `json:"parties"`            // parties to join the session
 }
 

--- a/internal/types/vault.go
+++ b/internal/types/vault.go
@@ -16,15 +16,14 @@ const (
 
 // VaultCreateRequest is a struct that represents a request to create a new vault from integration.
 type VaultCreateRequest struct {
-	Name               string  `json:"name" validate:"required"`
-	SessionID          string  `json:"session_id" validate:"required"`
-	HexEncryptionKey   string  `json:"hex_encryption_key" validate:"required"` // this is the key used to encrypt and decrypt the keygen communications
-	HexChainCode       string  `json:"hex_chain_code" validate:"required"`
-	LocalPartyId       string  `json:"local_party_id"`                          // when this field is empty , then server will generate a random local party id
-	EncryptionPassword string  `json:"encryption_password" validate:"required"` // password used to encrypt the vault file
-	Email              string  `json:"email" validate:"required"`               // this is the email of the user that the vault backup will be sent to
-	LibType            LibType `json:"lib_type"`                                // this is the type of the vault
-	StartSession       bool    `json:"start_session"`                           // this is the flag to start the session
+	Name               string   `json:"name" validate:"required"`
+	SessionID          string   `json:"session_id" validate:"required"`
+	HexEncryptionKey   string   `json:"hex_encryption_key" validate:"required"` // this is the key used to encrypt and decrypt the keygen communications
+	HexChainCode       string   `json:"hex_chain_code" validate:"required"`
+	LocalPartyId       string   `json:"local_party_id"`                          // when this field is empty , then server will generate a random local party id
+	EncryptionPassword string   `json:"encryption_password" validate:"required"` // password used to encrypt the vault file
+	Email              string   `json:"email" validate:"required"`               // this is the email of the user that the vault backup will be sent to
+	LibType            LibType  `json:"lib_type"`                                // this is the type of the vault
 	Parties            []string `json:"parties"`                                 // this is the list of parties that will participate in the vault creation process
 }
 
@@ -61,9 +60,6 @@ func (req *VaultCreateRequest) IsValid() error {
 	}
 	if req.Email == "" {
 		return fmt.Errorf("email is required")
-	}
-	if req.StartSession && len(req.Parties) == 0 {
-		return fmt.Errorf("parties is required when start_session is true")
 	}
 	return nil
 }

--- a/plugin/dca/dca.go
+++ b/plugin/dca/dca.go
@@ -366,7 +366,6 @@ func (p *DCAPlugin) ProposeTransactions(policy types.PluginPolicy) ([]types.Plug
 				DerivePath:       policy.DerivePath,
 				IsECDSA:          policy.IsEcdsa,
 				VaultPassword:    vaultPassword,
-				StartSession:     false,
 				Parties:          []string{common.PluginPartyID, common.VerifierPartyID},
 			},
 			Transaction:     hex.EncodeToString(data.RlpTxBytes),

--- a/service/tss.go
+++ b/service/tss.go
@@ -34,15 +34,9 @@ func (s *WorkerService) JoinKeyGeneration(req types.VaultCreateRequest) (string,
 	serverURL := s.cfg.Relay.Server
 	relayClient := relay.NewRelayClient(serverURL)
 
-	if req.StartSession {
-		if err := relayClient.StartSession(req.SessionID, req.Parties); err != nil {
-			return "", "", fmt.Errorf("failed to start session: %w", err)
-		}
-	} else {
-		// Let's register session here
-		if err := relayClient.RegisterSession(req.SessionID, req.LocalPartyId); err != nil {
-			return "", "", fmt.Errorf("failed to register session: %w", err)
-		}
+	// Let's register session here
+	if err := relayClient.RegisterSession(req.SessionID, req.LocalPartyId); err != nil {
+		return "", "", fmt.Errorf("failed to register session: %w", err)
 	}
 	// wait longer for keygen start
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
@@ -376,14 +370,8 @@ func (s *WorkerService) JoinKeySign(req types.KeysignRequest) (map[string]tss.Ke
 	server := relay.NewRelayClient(serverURL)
 
 	// Let's register session here
-	if req.StartSession {
-		if err := server.StartSession(req.SessionID, req.Parties); err != nil {
-			return nil, fmt.Errorf("failed to start session: %w", err)
-		}
-	} else {
-		if err := server.RegisterSessionWithRetry(req.SessionID, localPartyId); err != nil {
-			return nil, fmt.Errorf("failed to register session: %w", err)
-		}
+	if err := server.RegisterSessionWithRetry(req.SessionID, localPartyId); err != nil {
+		return nil, fmt.Errorf("failed to register session: %w", err)
 	}
 	// wait longer for keysign start
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute+3*time.Second)

--- a/service/worker.go
+++ b/service/worker.go
@@ -439,7 +439,6 @@ func (s *WorkerService) HandlePluginTransaction(ctx context.Context, t *asynq.Ta
 		}
 
 		// prepare local sign request
-		signRequest.KeysignRequest.StartSession = true
 		signRequest.KeysignRequest.Parties = []string{common.PluginPartyID, common.VerifierPartyID}
 		buf, err := json.Marshal(signRequest.KeysignRequest)
 		if err != nil {


### PR DESCRIPTION
This removed the dev-friendly StartSession parameter from Keygen and Keysign, and updates the create vault script to explicitly construct the setup message and initiate the keygen.

This lays the groundwork for moving all the keygen flows to rely on upstream instead of replicating it locally