### PR TITLE
plugins/payroll: export config variables

### DIFF
--- a/plugin/payroll/payroll.go
+++ b/plugin/payroll/payroll.go
@@ -21,7 +21,7 @@ type PayrollPlugin struct {
 }
 
 type PayrollPluginConfig struct {
-	rpcURL string `mapstructure:"rpc_url" json:"rpc_url"`
+	RpcURL string `mapstructure:"rpc_url" json:"rpc_url"`
 }
 
 func NewPayrollPlugin(db storage.DatabaseStorage, logger logrus.FieldLogger, rawConfig map[string]interface{}) (*PayrollPlugin, error) {
@@ -30,7 +30,7 @@ func NewPayrollPlugin(db storage.DatabaseStorage, logger logrus.FieldLogger, raw
 		return nil, err
 	}
 
-	rpcClient, err := ethclient.Dial(cfg.rpcURL)
+	rpcClient, err := ethclient.Dial(cfg.RpcURL)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Exports the config fields so that viper can set them