### PR TITLE
go.mod: upstream vultisigner -> vultiserver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,14 +16,14 @@ require (
 	github.com/labstack/echo/v4 v4.12.0
 	github.com/labstack/gommon v0.4.2
 	github.com/pressly/goose/v3 v3.23.0
-	github.com/redis/go-redis/v9 v9.7.0
+	github.com/redis/go-redis/v9 v9.7.3
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/viper v1.18.2
 	github.com/stretchr/testify v1.9.0
 	github.com/vultisig/commondata v0.0.0-20250331230745-5c4b32017c5b
 	github.com/vultisig/go-wrappers v0.0.0-20250403041248-86911e8aa33f
 	github.com/vultisig/mobile-tss-lib v0.0.0-20250316003201-2e7e570a4a74
-	github.com/vultisig/vultisigner v0.0.0-20250414071209-491f6b4b9c3b
+	github.com/vultisig/vultiserver v0.0.0-20250421043311-443d711d503d
 	google.golang.org/protobuf v1.35.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -298,8 +298,8 @@ github.com/prometheus/common v0.47.0 h1:p5Cz0FNHo7SnWOmWmoRozVcjEp0bIVU8cV7OShpj
 github.com/prometheus/common v0.47.0/go.mod h1:0/KsvlIEfPQCQ5I2iNSAWKPZziNCvRs5EC6ILDTlAPc=
 github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo=
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
-github.com/redis/go-redis/v9 v9.7.0 h1:HhLSs+B6O021gwzl+locl0zEDnyNkxMtf/Z3NNBMa9E=
-github.com/redis/go-redis/v9 v9.7.0/go.mod h1:f6zhXITC7JUJIlPEiBOTXxJgPLdZcA93GewI7inzyWw=
+github.com/redis/go-redis/v9 v9.7.3 h1:YpPyAayJV+XErNsatSElgRZZVCwXX9QzkKYNvO7x0wM=
+github.com/redis/go-redis/v9 v9.7.3/go.mod h1:bGUrSggJ9X9GUmZpZNEOQKaANxSGgOEBRltRTZHSvrA=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
@@ -379,8 +379,8 @@ github.com/vultisig/go-wrappers v0.0.0-20250403041248-86911e8aa33f h1:124Xlloih1
 github.com/vultisig/go-wrappers v0.0.0-20250403041248-86911e8aa33f/go.mod h1:UfGCxUQW08kiwxyNBiHwXe+ePPuBmHVVS+BS51aU/Jg=
 github.com/vultisig/mobile-tss-lib v0.0.0-20250316003201-2e7e570a4a74 h1:goqwk4nQ/NEVIb3OPP9SUx7/u9ZfsUIcd5fIN/e4DVU=
 github.com/vultisig/mobile-tss-lib v0.0.0-20250316003201-2e7e570a4a74/go.mod h1:nOykk4nOy1L3yXtLSlYvVsgizBnCQ3tR2N5uwGPdvaM=
-github.com/vultisig/vultisigner v0.0.0-20250414071209-491f6b4b9c3b h1:7lrmJcIB/o+VwueAYP+8xrRehgJD9icqPgUeX4CxZ5w=
-github.com/vultisig/vultisigner v0.0.0-20250414071209-491f6b4b9c3b/go.mod h1:gmN7LQ2KiqDAPuYjl9CRNAHFgwHQDKZI5e10RE3e/jA=
+github.com/vultisig/vultiserver v0.0.0-20250421043311-443d711d503d h1:cXQm8SK1TJe/YIdCtQNrItVctABI3xe/L5Te0PmohTY=
+github.com/vultisig/vultiserver v0.0.0-20250421043311-443d711d503d/go.mod h1:HwP2IgW6Mcu/gX8paFuKvfibrGE9UmPgkOFTub6dskM=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/service/keysign_dkls.go
+++ b/service/keysign_dkls.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/vultisig/vultiserver-plugin/internal/types"
 	"github.com/vultisig/vultiserver-plugin/relay"
-	vcommon "github.com/vultisig/vultisigner/common"
+	vcommon "github.com/vultisig/vultiserver/common"
 )
 
 func (t *DKLSTssService) ProcessDKLSKeysign(req types.KeysignRequest) (map[string]tss.KeysignResponse, error) {

--- a/service/worker.go
+++ b/service/worker.go
@@ -30,7 +30,7 @@ import (
 	"github.com/vultisig/vultiserver-plugin/relay"
 	"github.com/vultisig/vultiserver-plugin/storage"
 	"github.com/vultisig/vultiserver-plugin/storage/postgres"
-	"github.com/vultisig/vultisigner/contexthelper"
+	"github.com/vultisig/vultiserver/contexthelper"
 )
 
 type WorkerService struct {

--- a/service/worker_dkls.go
+++ b/service/worker_dkls.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/vultisig/vultiserver-plugin/internal/types"
 	"github.com/vultisig/vultiserver-plugin/relay"
-	"github.com/vultisig/vultisigner/contexthelper"
+	"github.com/vultisig/vultiserver/contexthelper"
 )
 
 func (s *WorkerService) HandleKeyGenerationDKLS(ctx context.Context, t *asynq.Task) error {

--- a/storage/redis_storage.go
+++ b/storage/redis_storage.go
@@ -7,7 +7,7 @@ import (
 	"github.com/redis/go-redis/v9"
 
 	"github.com/vultisig/vultiserver-plugin/config"
-	"github.com/vultisig/vultisigner/contexthelper"
+	"github.com/vultisig/vultiserver/contexthelper"
 )
 
 type RedisStorage struct {


### PR DESCRIPTION
Upstream renamed the package to `vultiserver` to align with their repo name, so just bumping that