### PR TITLE
fix: missing selected token id in FormContext

### DIFF
--- a/plugins-ui/src/modules/policy/components/policy-form/PolicyForm.tsx
+++ b/plugins-ui/src/modules/policy/components/policy-form/PolicyForm.tsx
@@ -132,7 +132,9 @@ const PolicyForm = ({ data, onSubmitCallback }: PolicyFormProps) => {
           readonly={!!policyId}
           formContext={{
             editing: !!policyId,
-            sourceTokenId: formData.source_token_id as string, // sourceTokenId is needed in WeiConverter/TitleFieldTemplate and probably on most of the existing plugins to get the rigth decimal places based on token address
+            sourceTokenId:
+              (formData.source_token_id as string) ||
+              (formData.token_id as string[])?.at(0), // sourceTokenId is needed in WeiConverter/TitleFieldTemplate and probably on most of the existing plugins to get the rigth decimal places based on token address
             destinationTokenId: formData.destination_token_id as string, // destinationTokenId is needed in TitleFieldTemplate
           }}
         />

--- a/plugins-ui/src/modules/policy/models/policy.ts
+++ b/plugins-ui/src/modules/policy/models/policy.ts
@@ -1,6 +1,8 @@
 import { RJSFSchema } from "@rjsf/utils";
 
-export type Policy<T = string | number | boolean | null | undefined> = {
+export type Policy<
+  T = string | number | boolean | string[] | null | undefined,
+> = {
   [key: string]: T | Policy<T>;
 };
 


### PR DESCRIPTION
We are using FormContext to populate selected token for DCA and Payroll and based on the selected token we format the amount with the corresponding decimals