### PR TITLE
improvement: update policy completion state

### DIFF
--- a/plugin/dca/dca.go
+++ b/plugin/dca/dca.go
@@ -153,6 +153,7 @@ func (p *Plugin) SigningComplete(
 	err = p.completePolicyIfAllSwapsDone(ctx, policy, signRequest.TransactionType)
 	if err != nil {
 		p.logger.Errorf("complete policy failed: %v", err)
+		return fmt.Errorf("complete policy failed: %s", policy.ID)
 	}
 
 	return nil

--- a/plugin/dca/dca.go
+++ b/plugin/dca/dca.go
@@ -738,7 +738,6 @@ func (p *Plugin) completePolicyIfAllSwapsDone(ctx context.Context, policy types.
 		if err := p.completePolicy(context.Background(), policy); err != nil {
 			return fmt.Errorf("fail to complete policy: %w", err)
 		}
-		return ErrCompletedPolicy
 	}
 
 	return nil
@@ -747,7 +746,7 @@ func (p *Plugin) completePolicyIfAllSwapsDone(ctx context.Context, policy types.
 func (p *Plugin) completePolicy(ctx context.Context, policy types.PluginPolicy) error {
 	p.logger.WithFields(logrus.Fields{
 		"policy_id": policy.ID,
-	}).Info("DCA: All orders completed, no transactions to propose")
+	}).Info("DCA: All orders completed")
 
 	err := p.db.WithTransaction(ctx, func(ctx context.Context, tx pgx.Tx) error {
 		policy.Progress = "DONE"


### PR DESCRIPTION
Problem: https://github.com/LimeChain/vultisig-mono/issues/166

## Changes
- Complete policy check step on dca signing complete

## Implementation notes
- policy can also be completed in ProposeTransactions (plugin) and ValidateProposedTransactions (verifier). Now that we complete the policy in SigningComplete, we should not reach these cases, where all tx are mined, but policy in not completed. The code checks remain only as part of the overall validation.